### PR TITLE
nfc: remove FITS references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ This repository also hosts scripts and codes used for some GeoNet's data blogs. 
 | ------------- | ------------- |
 | [AWS Open Data](./AWS_Open_Data) | A file README.md describing GeoNet's data available through AWS Open Data |
 | [FDSN](./FDSN) | Demonstrates how to access data through GeoNet's different FDSN web services (Dataselect, Station and Event). These tutorials are applicable to **seismic**, **acoustic-infrasound**, and **tsunami gauge (full sample rate)** data sets. |
-| [FITS](./FITS) | Shows how to retrieve and use data from [FITS](https://fits.geonet.org.nz/api-docs/). FITS is used to access **daily GNSS position data**, and is in the process of being replaced by [Tilde](https://tilde.geonet.org.nz/). |
 | [Tilde](./Tilde) | Shows how to retrieve data from GeoNet's [Tilde API](https://tilde.geonet.org.nz/). These tutorials apply to **DART**, **envirosensor**, **tsunami gauge (down-sampled)**, and **GNSS displacement** data. Tutorials cover Tilde's data, stats, and data summary APIs. Further examples using Tilde are available in the volcano tutorials.|
 
 ### By data type

--- a/Volcano/README.md
+++ b/Volcano/README.md
@@ -14,7 +14,7 @@ When using Tilde, the volcano-specific notebooks only use the Tilde Data Endpoin
 | File | Description |
 |------|-------------|
 | [Envirosensor](./Volcano_data_envirosensor.ipynb) | Demonstrates how to retrieve and graph multiGas data, fumarole and water temperature data, water level data, self potential and ground temperature data, wind data, and rainfall data.|
-| [GNSS](./Volcano_data_gnss.ipynb) | Demonstrates how to retrieve and graph GNSS data. These data are currently delivered by [FITS](https://fits.geonet.org.nz/api-docs/) but will move to Tilde |
+| [GNSS](./Volcano_data_gnss.ipynb) | Demonstrates how to retrieve and graph displacement data obtained for the GNSS sensor network. |
 | [Manually collected](./Volcano_data_manualcollect.ipynb) | Demonstrates how to retrieve and graph water chemistry data, airborne gas emission rate data, soil gas data, lake levelling (Lake Taupō) data, and how to create spreadsheet-like output files for water chemistry data.|
 | [ScanDOAS](./Volcano_data_scandoas.ipynb) | Demonstrates how to retrieve and graph scanDOAS data, including working with data from multiple sensors.|
 | [Data aggregation](./Volcano_data_aggregation.ipynb) | Demonstrates how to use Tilde's data aggregation functions with volcano data.|


### PR DESCRIPTION
Hi @rumachan ,

there are no FITS tutorials I can see pending, but the README were still referencing to it.
